### PR TITLE
Stop using reserved JavaScript keyword `package`

### DIFF
--- a/lib/autosave-delay.js
+++ b/lib/autosave-delay.js
@@ -19,7 +19,7 @@ import { CompositeDisposable } from 'atom'; // Atom event handle
 import { Package } from './package'; // Our package class
 import debounce from 'lodash.debounce';
 
-const package = new Package();
+const pack = new Package();
 
 export default {
 
@@ -36,15 +36,15 @@ export default {
             let activeWorkspace = atom.views.getView(editor);
 
             // editor.onDidStopChanging( debounce(() =>
-            //     package.onDidStopChanging(editor, activeWorkspace), 500));
+            //     pack.onDidStopChanging(editor, activeWorkspace), 500));
 
             activeWorkspace.addEventListener('autocomplete-plus:cancel', (e) =>
-                package.onAutoCompleteClose(editor) );
+                pack.onAutoCompleteClose(editor) );
 
 
             editor.onDidChangeCursorPosition(
                 debounce((ev) =>
-                    package.onDidChangeCursorPosition(editor, activeWorkspace), 500));
+                    pack.onDidChangeCursorPosition(editor, activeWorkspace), 500));
         });
     },
 

--- a/spec/package-spec.js
+++ b/spec/package-spec.js
@@ -7,11 +7,11 @@ describe('In the file package.js', () => {
 
     let editor,
         workspace,
-        package;
+        pack;
 
     beforeEach(() => {
 
-        package = new Package();
+        pack = new Package();
         workspace = jasmine.createSpyObj('workspace', ['querySelector']);
         editor = jasmine.createSpyObj('editor', ['save', 'isModified', 'getPath']);
     });
@@ -29,7 +29,7 @@ describe('In the file package.js', () => {
 
         it('Should call the save method', () => {
 
-            package.trigger(editor); // Triggering spy
+            pack.trigger(editor); // Triggering spy
 
             expect( editor.save ).toHaveBeenCalled();
         });
@@ -41,14 +41,14 @@ describe('In the file package.js', () => {
 
             editor.isModified.andReturn(false); // Setting value returned by isModified()
 
-            expect( package._shouldSave(editor) ).toBe( false );
+            expect( pack._shouldSave(editor) ).toBe( false );
         });
 
         it("Should return false if 'getPath()' is undefined", () => {
 
             editor.getPath.andReturn(undefined); // Setting value returned by isModified()
 
-            expect( package._shouldSave(editor) ).toBe( false );
+            expect( pack._shouldSave(editor) ).toBe( false );
         });
 
         it("Should return true if both are true/defined", () => {
@@ -56,7 +56,7 @@ describe('In the file package.js', () => {
             editor.isModified.andReturn(true); // Setting value returned by isModified()
             editor.getPath.andReturn('path/whatevz.js'); // Setting value returned by isModified()
 
-            expect( package._shouldSave(editor) ).toBe( true );
+            expect( pack._shouldSave(editor) ).toBe( true );
         });
     });
 
@@ -64,7 +64,7 @@ describe('In the file package.js', () => {
 
         it("Should call the workspace's querySelector method", () => {
 
-            package._autocompleteTriggered( workspace ); // Triggering spy
+            pack._autocompleteTriggered( workspace ); // Triggering spy
 
             expect( workspace.querySelector ).toHaveBeenCalled();
         });
@@ -73,14 +73,14 @@ describe('In the file package.js', () => {
 
             workspace.querySelector.andReturn(undefined);
 
-            expect( package._autocompleteTriggered( workspace ) ).toBe( false );
+            expect( pack._autocompleteTriggered( workspace ) ).toBe( false );
         });
 
         it("Should return true if '.autocomplete-plus' class is found", () => {
 
             workspace.querySelector.andReturn(true);
 
-            expect( package._autocompleteTriggered( workspace ) ).toBe( true );
+            expect( pack._autocompleteTriggered( workspace ) ).toBe( true );
         });
     });
 });


### PR DESCRIPTION
In the process of upgrading babel in Atom core (https://github.com/atom/atom/pull/13823) we have noticed this package uses JavaScript features that are either deprecated or that are incompatible with the language specification.

This pull request changes the code to stop using such features so that the package keeps working when the babel upgrade will be merged and released.

I have enabled edits from maintainers, so feel free to make any changes to this branch! Also, please let me know if you have any questions or concerns and if I can help somehow. Thanks!